### PR TITLE
Patches to fix wipe data issue

### DIFF
--- a/fs_mgr-Yes-you-can.patch
+++ b/fs_mgr-Yes-you-can.patch
@@ -1,0 +1,46 @@
+From 57c6e39bc519d93b34ff51a698b2487a9d430add Mon Sep 17 00:00:00 2001
+From: nebrassy <nebras30@gmail.com>
+Date: Sun, 22 Sep 2024 16:30:15 +0200
+Subject: [PATCH] fs_mgr: Yes you can
+
+Change-Id: I3b38173704e659ac9037183b1b029874fd7cecc5
+---
+ fs_mgr/libfiemap/image_manager.cpp | 6 ++++--
+ fs_mgr/libsnapshot/snapshot.cpp    | 4 ++--
+ 2 files changed, 6 insertions(+), 4 deletions(-)
+
+diff --git a/fs_mgr/libfiemap/image_manager.cpp b/fs_mgr/libfiemap/image_manager.cpp
+index c416f4df44..d29fc8d938 100644
+--- a/fs_mgr/libfiemap/image_manager.cpp
++++ b/fs_mgr/libfiemap/image_manager.cpp
+@@ -274,8 +274,10 @@ bool ImageManager::DeleteBackingImage(const std::string& name) {
+     }
+ 
+     if (device_info_.is_recovery.value()) {
+-        LOG(ERROR) << "Cannot remove images backed by /data in recovery";
+-        return false;
++        if (android::base::GetProperty("twrp.decrypt.done", "") != "true") {
++            LOG(ERROR) << "Cannot remove images backed by /data if data is encrypted";
++            return false;
++        }
+     }
+ 
+     std::string message;
+diff --git a/fs_mgr/libsnapshot/snapshot.cpp b/fs_mgr/libsnapshot/snapshot.cpp
+index 64637c2849..bb91e9ea78 100644
+--- a/fs_mgr/libsnapshot/snapshot.cpp
++++ b/fs_mgr/libsnapshot/snapshot.cpp
+@@ -711,8 +711,8 @@ bool SnapshotManager::DeleteSnapshot(LockedFile* lock, const std::string& name)
+     // We can't delete snapshots in recovery. The only way we'd try is it we're
+     // completing or canceling a merge in preparation for a data wipe, in which
+     // case, we don't care if the file sticks around.
+-    if (device_->IsRecovery()) {
+-        LOG(INFO) << "Skipping delete of snapshot " << name << " in recovery.";
++    if (android::base::GetProperty("twrp.decrypt.done", "") != "true") {
++        LOG(INFO) << "Skipping delete of snapshot " << name << " in recovery because data is encrypted.";
+         return true;
+     }
+ 
+-- 
+2.43.0
+

--- a/partitionmanager-unmap-all-dynamic-partitions.patch
+++ b/partitionmanager-unmap-all-dynamic-partitions.patch
@@ -1,0 +1,44 @@
+From 527ab6fd0d545ac6cd588a02fcf2cd28192f909e Mon Sep 17 00:00:00 2001
+From: nebrassy <nebras30@gmail.com>
+Date: Mon, 23 Sep 2024 12:34:32 +0200
+Subject: [PATCH] partitionmanager: unmap all dynamic partitions not included
+ in fstab
+
+Change-Id: I6dbaf62f8354a8ece87a680d87f317d2a5d5bb14
+---
+ partitionmanager.cpp | 19 +++++++++++++++++++
+ 1 file changed, 19 insertions(+)
+
+diff --git a/partitionmanager.cpp b/partitionmanager.cpp
+index 6858df1c..ce343b75 100755
+--- a/partitionmanager.cpp
++++ b/partitionmanager.cpp
+@@ -3761,6 +3761,25 @@ bool TWPartitionManager::Unmap_Super_Devices() {
+ 			++iter;
+ 		}
+ 	}
++
++	const std::string block_path = "/dev/block/mapper/";
++	DIR* d = opendir(block_path.c_str());
++	if (d != NULL) {
++		struct dirent* de;
++		while ((de = readdir(d)) != NULL) {
++			std::string partition = de->d_name;
++			LOGINFO("partition: %s \n", partition.c_str());
++			if((strcmp(partition.c_str(),"userdata") != 0) && (strcmp(partition.c_str(),".") != 0) && (strcmp(partition.c_str(),"..") != 0) && (strcmp(partition.c_str(),"by-uuid") != 0)){
++				LOGINFO("removing dynamic partition: %s\n", partition.c_str());
++				destroyed = DestroyLogicalPartition(partition);
++				if (!destroyed) {
++					closedir(d);
++					return false;
++				}
++			}
++                }
++	closedir(d);
++	}
+ 	return true;
+ }
+ 
+-- 
+2.43.0
+


### PR DESCRIPTION
For me on mondrian i cant wipe data always unable to map dynamic partitions until i add this patch to the github actions [OrangeFox-Action-Builder] "partitionmanager-unmap-all-dynamic-partitions.patch" but it needs from me to wipe data twice 1st trial gonna gimme the same issue and the second try wipe data successfully but without this patch i cant wipe data this patch should fix it but need to wipe data twice 
![photo_2025-01-15_23-55-58](https://github.com/user-attachments/assets/3e9222dc-5808-4f78-8e2f-900ddd60e026)

EDIT: the other patch already merged not needed